### PR TITLE
Loosen the restriction on cursor character set

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -191,7 +191,7 @@ GET https://myservice/my-kind-of-entity/feed/v1?cursor0=1000240213123&cursor1=12
 * **cursorN**: Pass in one cursor for each partition you wish to
   consume; where `N` is a number in the range `0...n-1`.
   Each `cursor` is an opaque string that should be passed
-  back as-is, but is limited to the base64 character set. Two special
+  back as-is, but is limited to ASCII printable characters. Two special
   cursors are used; `_first` means to start from the beginning of time,
   and `_last` starts at an arbitrary point "around now".
 


### PR DESCRIPTION
As it stands ("limited to the base64 character set"), there is some confusion as to exactly _which_ base64 variant is allowed. The "standard" base64 variant is what one usually mean when just saying "base64" without qualification, however the URL-safe base64 variant is more appropriate for use in URLs. Both variants are defined in RFC4648.

We could modify the sentence to specify which variant(s) of base64 are allowed, but it seems better to just relax this restriction a bit, as the intention isn't to force implementors to encode the cursor in a specific way, but rather to impose some minimal restrictions on what character values the cursor can have, so that one doesn't have to consider which character set the cursor is encoded in, or handle raw byte values.