### PR TITLE
Remove requirement that the feed URL ends with /feed/v1

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -115,9 +115,7 @@ this database is streamed as events to Event Hub.
 The publisher can then additionally make the events available in a polling
 interface, which is made available to select consumers.
 The endpoint the backend makes the API available on is not defined
-(and each backend can choose to expose several event feeds on different routes),
-but to signal that this specification is followed the suffix
-of the URI should be `..../feed/v1/`.
+(and each backend can choose to expose several event feeds on different routes).
 
 
 ### Partitions

--- a/go/README.md
+++ b/go/README.md
@@ -73,6 +73,9 @@ for myStillWantToReadEvents {
 The URL in the `NewClient` constructor must now be the full URL to the ZeroEventHub endpoint.
 Previously, the client would append `/feed/v1` to the URL given.
 
+The `Handler` function now also requires a path argument. Previously, it was hardcoded to
+use the path `/feed/v1`.
+
 ## Server
 
 This library implements the transport layer, but the basic paginate-over-events

--- a/go/README.md
+++ b/go/README.md
@@ -68,6 +68,10 @@ for myStillWantToReadEvents {
 
 ```
 
+### Breaking changes
+
+The URL in the `NewClient` constructor must now be the full URL to the ZeroEventHub endpoint.
+Previously, the client would append `/feed/v1` to the URL given.
 
 ## Server
 

--- a/go/api.go
+++ b/go/api.go
@@ -161,13 +161,13 @@ func (page *EventPageSingleType[T]) Event(partitionID int, h map[string]string, 
 }
 
 // Handler wraps API in a http.Handler.
-func Handler(logger logrus.FieldLogger, api API) http.Handler {
+func Handler(path string, logger logrus.FieldLogger, api API) http.Handler {
 	if logger == nil {
 		logger = logrus.StandardLogger()
 	}
 	router := mux.NewRouter()
 	router.Methods(http.MethodGet).
-		Path("/feed/v1").
+		Path(path).
 		HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			query := request.URL.Query()
 			if !query.Has("n") {

--- a/go/api.go
+++ b/go/api.go
@@ -297,7 +297,7 @@ func (c Client) FetchEvents(ctx context.Context, cursors []Cursor, pageSizeHint 
 		return ErrCursorsMissing
 	}
 
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/feed/v1", c.url), nil)
+	req, err := http.NewRequest(http.MethodGet, c.url, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This removes the requirement from the speficiation that the feed URL should end with /feed/v1, and updates the Go client and server so that it no longer hardcodes /feed/v1 in the NewClient constructor and Handler function, respectively.