### PR TITLE
Python: Apply properties from session to request

### DIFF
--- a/python/zeroeventhub/pyproject.toml
+++ b/python/zeroeventhub/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/vippsas/zeroeventhub"
 keywords = ["event-streaming"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 requests = "^2.28.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/python/zeroeventhub/zeroeventhub/client.py
+++ b/python/zeroeventhub/zeroeventhub/client.py
@@ -113,7 +113,8 @@ class Client:
         if headers:
             params["headers"] = ",".join(headers)
 
-        return requests.Request("GET", self.url, params=params).prepare()
+        request = requests.Request("GET", self.url, params=params)
+        return self._session.prepare_request(request)
 
     def _process_response(self, res: requests.Response, event_receiver: EventReceiver) -> None:
         """


### PR DESCRIPTION
## Changes 📝
* Fix bug where properties from the provided session was not sent when fetching events

See: https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests
> However, the above code will lose some of the advantages of having a Requests [Session](https://requests.readthedocs.io/en/latest/api/#requests.Session) object. In particular, [Session](https://requests.readthedocs.io/en/latest/api/#requests.Session)-level state such as cookies will not get applied to your request. To get a [PreparedRequest](https://requests.readthedocs.io/en/latest/api/#requests.PreparedRequest) with that state applied, replace the call to [Request.prepare()](https://requests.readthedocs.io/en/latest/api/#requests.Request.prepare) with a call to [Session.prepare_request()](https://requests.readthedocs.io/en/latest/api/#requests.Session.prepare_request), like this: