### PR TITLE
build: improve Mypy config

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,10 +37,8 @@ jobs:
         name: Run flake8
       - run: poetry run pylint zeroeventhub/
         name: Run pylint
-      - run: poetry run mypy --disallow-untyped-defs ./zeroeventhub/
+      - run: poetry run mypy
         name: Check types
-      - run: poetry run mypy --check-untyped-defs ./tests/
-        name: Check types in tests
       # test
       - run: poetry run coverage run --branch -m pytest
         name: Run unit tests

--- a/python/zeroeventhub/README.md
+++ b/python/zeroeventhub/README.md
@@ -69,6 +69,5 @@ Also, to pass the CI checks, you may want to run the following before pushing yo
 ```sh
 poetry run pylint ./zeroeventhub/
 poetry run flake8
-poetry run mypy --check-untyped-defs ./tests/
-poetry run mypy --disallow-untyped-defs ./zeroeventhub/
+poetry run mypy
 ```

--- a/python/zeroeventhub/pyproject.toml
+++ b/python/zeroeventhub/pyproject.toml
@@ -48,7 +48,7 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"
-# `disallow_untyped_defs` has to be explicitly disabled because it is enbaled by
+# `disallow_untyped_defs` has to be explicitly disabled because it is enabled by
 # `strict`, and just setting `check_untyped_defs` does not disable it, even
 # though it is from the same option group as `check_untyped_defs`. With it
 # enabled Mypy complains about test functions without type annotations.

--- a/python/zeroeventhub/pyproject.toml
+++ b/python/zeroeventhub/pyproject.toml
@@ -34,9 +34,26 @@ build-backend = "poetry.core.masonry.api"
 [tool.black]
 line-length = 100
 
+[tool.mypy]
+files = "zeroeventhub,tests"
+python_version = "3.9"
+strict = true
+warn_unreachable = true
+warn_unused_configs = true
+explicit_package_bases = true
+
 [[tool.mypy.overrides]]
 module = "mock_protocol.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+# `disallow_untyped_defs` has to be explicitly disabled because it is enbaled by
+# `strict`, and just setting `check_untyped_defs` does not disable it, even
+# though it is from the same option group as `check_untyped_defs`. With it
+# enabled Mypy complains about test functions without type annotations.
+disallow_untyped_defs = false
+check_untyped_defs = true
 
 [tool.pylint.parameter_documentation]
 accept-no-param-doc = true

--- a/python/zeroeventhub/zeroeventhub/__init__.py
+++ b/python/zeroeventhub/zeroeventhub/__init__.py
@@ -6,3 +6,17 @@ from .event_receiver import EventReceiver
 from .errors import APIError, ErrCursorsMissing
 from .constants import ALL_HEADERS
 from .page_event_receiver import Event, PageEventReceiver
+
+
+__all__ = [
+    "Client",
+    "Cursor",
+    "FIRST_CURSOR",
+    "LAST_CURSOR",
+    "EventReceiver",
+    "APIError",
+    "ErrCursorsMissing",
+    "ALL_HEADERS",
+    "Event",
+    "PageEventReceiver",
+]

--- a/python/zeroeventhub/zeroeventhub/client.py
+++ b/python/zeroeventhub/zeroeventhub/client.py
@@ -1,7 +1,7 @@
 """Module containing client-side related code for ZeroEventHub"""
 
 import json
-from typing import Dict, Optional, Any, Sequence
+from typing import Dict, Optional, Any, Sequence, Union
 import requests
 
 from .cursor import Cursor
@@ -101,7 +101,7 @@ class Client:
         :param headers: An optional sequence containing event headers desired in the response.
         :return: the http request
         """
-        params: Dict[str, str | int] = {
+        params: Dict[str, Union[str, int]] = {
             "n": self.partition_count,
         }
         if page_size_hint:


### PR DESCRIPTION
The current Mypy config requires that developers run Mypy correctly:

```bash
poetry run mypy --disallow-untyped-defs ./zeroeventhub/
poetry run mypy --check-untyped-defs ./tests/
```

This change configures mypy so that developers can just run `poetry run mypy` to get it to do the right thing.

Other changes:

- Enabled strict mode for Mypy and fixed the errors that came up, which was that `__all__` was not set in `zeroeventhub/__init__.py`.
- Set the Python version in Mypy config, so that mypy reports unsupported constructs and elimintated the use of unsupported constructs: `|` was used for Union, this is not supported for Python 3.9.
- Enabled warnings for unreachable code and unused configs.