### PR TITLE
Don't run PyPI publish workflow on every push.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,8 +2,6 @@ name: Publish Python client to PyPI
 
 on:
   push:
-    branches:
-      - main
     tags:
       - python/v*
 


### PR DESCRIPTION
Apparently branch+tag means that either, not both, have to match.