### PR TITLE
FeedAPI support

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -24,7 +24,8 @@ type Client struct {
 
 var _ EventFetcher = &Client{}
 
-// NewClient is a constructor for the Client.
+// NewClient is a constructor for the Client. The partitionCount parameter says how many partitions to expect
+// in the V1 protocol; if you do not wish to support the V1 protocol you may pass `NoV1Support`
 func NewClient(url string, partitionCount int) Client {
 	return Client{
 		httpClient: http.DefaultClient,
@@ -57,18 +58,89 @@ func (c Client) WithLogger(logger logrus.FieldLogger) (r Client) {
 	return
 }
 
-// FetchEvents is a client-side implementation that queries the server and properly deserializes received data.
-func (c Client) FetchEvents(ctx context.Context, token string, partitionID int, cursor string, r EventReceiver, options Options) error {
-	type checkpointOrEvent struct {
-		PartitionId int `json:"partition"`
-		// either this is set:
-		Cursor string `json:"cursor"`
-		// OR, these are set:
-		Headers map[string]string `json:"headers"`
-		Data    json.RawMessage   `json:"data"`
+type Partition struct {
+	Id                   int   `json:"id,string"`
+	Closed               bool  `json:"bool"`
+	StartsAfterPartition int   `json:"startsAfterPartition"`
+	CursorFromPartitions []int `json:"cursorFromPartitions"`
+}
+
+const V1Token = "_v1" // FeedInfo.Token = V1Token indicates to use v1 protocol
+const NoV1Support = 0
+
+type FeedInfo struct {
+	Token       string      `json:"token"`
+	Partitions  []Partition `json:"partitions"`
+	ExactlyOnce bool        `json:"exactlyOnce"`
+}
+
+func (c Client) Discover(ctx context.Context) (FeedInfo, error) {
+	req, err := http.NewRequest(http.MethodGet, c.url, nil)
+	if err != nil {
+		return FeedInfo{}, err
+	}
+	req = req.WithContext(ctx)
+	if err = c.requestProcessor(req); err != nil {
+		return FeedInfo{}, err
+	}
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return FeedInfo{}, err
+	}
+	defer func(body io.ReadCloser) {
+		_ = body.Close()
+	}(res.Body)
+
+	// Just always read it into a string, because we want to print it if something is wrong..
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return FeedInfo{}, err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, c.url, nil)
+	if res.StatusCode == http.StatusBadRequest && c.partitionCount != NoV1Support {
+		// We treat this as a sign that we are on ZeroEventHub v1 because we did not pass the &n parameter;
+		// fallback to special version 1 compatability mode. This is only done if
+		// partitionCount has been set up when making the client.
+		info := FeedInfo{
+			Token: V1Token,
+		}
+		for i := 0; i != c.partitionCount; i++ {
+			info.Partitions = append(info.Partitions, Partition{
+				Id: i,
+			})
+		}
+		return info, nil
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if len(responseBody) > 1000 {
+			responseBody = responseBody[:1000]
+		}
+		return FeedInfo{}, errors.Errorf("Unexpected status code: %d. Response body: %s", res.StatusCode, responseBody)
+	}
+
+	var info FeedInfo
+	err = json.Unmarshal(responseBody, &info)
+	if err != nil {
+		return FeedInfo{}, errors.Errorf("Failed to unmarshal FeedAPI response, error=%s, response=%s", err, responseBody)
+	}
+
+	return info, nil
+}
+
+// FetchEvents is a client-side implementation that queries the server and properly deserializes received data.
+func (c Client) FetchEvents(ctx context.Context, token string, partitionID int, cursor string, r EventReceiver, options Options) error {
+	if token == V1Token {
+		return c.FetchEventsV1(ctx, partitionID, cursor, r, options)
+	}
+
+	type checkpointOrEvent struct {
+		Cursor string `json:"cursor"`
+		// OR, this is set:
+		Data json.RawMessage `json:"data"`
+	}
+
+	req, err := http.NewRequest(http.MethodGet, c.url+"/events", nil)
 	if err != nil {
 		return err
 	}
@@ -76,11 +148,13 @@ func (c Client) FetchEvents(ctx context.Context, token string, partitionID int, 
 	req = req.WithContext(ctx)
 
 	q := req.URL.Query()
-	q.Add("n", fmt.Sprintf("%d", c.partitionCount))
+	q.Add("token", token)
+	q.Add("partition", strconv.Itoa(partitionID))
+	q.Add("cursor", cursor)
 	if options.PageSizeHint != DefaultPageSize {
 		q.Add("pagesizehint", fmt.Sprintf("%d", options.PageSizeHint))
 	}
-	q.Add(fmt.Sprintf("cursor%d", partitionID), cursor)
+
 	req.URL.RawQuery = q.Encode()
 
 	if err := c.requestProcessor(req); err != nil {
@@ -92,6 +166,7 @@ func (c Client) FetchEvents(ctx context.Context, token string, partitionID int, 
 		return err
 	}
 	defer func(body io.ReadCloser) {
+		_, _ = io.Copy(io.Discard, body)
 		_ = body.Close()
 	}(res.Body)
 
@@ -101,15 +176,15 @@ func (c Client) FetchEvents(ctx context.Context, token string, partitionID int, 
 			"requestUrl":   req.URL.String(),
 		}).WithContext(ctx)
 		if all, err := io.ReadAll(res.Body); err != nil {
-			log.WithField("event", "zeroeventhub.res_body_read_error").WithError(err).Error()
+			log.WithField("event", "feedapi.res_body_read_error").WithError(err).Error()
 			return err
 		} else {
 			if string(all) == "\n" || string(all) == "" {
-				err = errors.Errorf("empty response body")
+				err = errors.Errorf("response code %d, empty response body", res.StatusCode)
 			} else {
-				err = errors.Errorf("unexpected response body: %s", string(all))
+				err = errors.Errorf("response code %d, response body: %s", res.StatusCode, string(all))
 			}
-			log.WithField("event", "zeroeventhub.unexpected_response_body").WithError(err).Error()
+			log.WithField("event", "feedapi.unexpected_response_body").WithError(err).Error()
 			return err
 		}
 	}

--- a/go/client_v1.go
+++ b/go/client_v1.go
@@ -1,0 +1,100 @@
+package zeroeventhub
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+func (c Client) FetchEventsV1(ctx context.Context, partitionID int, cursor string, r EventReceiver, options Options) error {
+	type checkpointOrEvent struct {
+		PartitionId int `json:"partition"`
+		// either this is set:
+		Cursor string `json:"cursor"`
+		// OR, these are set:
+		Headers map[string]string `json:"headers"`
+		Data    json.RawMessage   `json:"data"`
+	}
+
+	req, err := http.NewRequest(http.MethodGet, c.url, nil)
+	if err != nil {
+		return err
+	}
+
+	req = req.WithContext(ctx)
+
+	q := req.URL.Query()
+	q.Add("n", fmt.Sprintf("%d", c.partitionCount))
+	if options.PageSizeHint != DefaultPageSize {
+		q.Add("pagesizehint", fmt.Sprintf("%d", options.PageSizeHint))
+	}
+	q.Add(fmt.Sprintf("cursor%d", partitionID), cursor)
+	req.URL.RawQuery = q.Encode()
+
+	if err := c.requestProcessor(req); err != nil {
+		return err
+	}
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func(body io.ReadCloser) {
+		_, _ = io.Copy(io.Discard, body)
+		_ = body.Close()
+	}(res.Body)
+
+	if res.StatusCode/100 != 2 {
+		log := c.logger.WithFields(logrus.Fields{
+			"responseCode": strconv.Itoa(res.StatusCode),
+			"requestUrl":   req.URL.String(),
+		}).WithContext(ctx)
+		if all, err := io.ReadAll(res.Body); err != nil {
+			log.WithField("event", "zeroeventhub.res_body_read_error").WithError(err).Error()
+			return err
+		} else {
+			if string(all) == "\n" || string(all) == "" {
+				err = errors.Errorf("empty response body")
+			} else {
+				err = errors.Errorf("unexpected response body: %s", string(all))
+			}
+			log.WithField("event", "zeroeventhub.unexpected_response_body").WithError(err).Error()
+			return err
+		}
+	}
+
+	scanner := bufio.NewScanner(res.Body)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		// we only partially parse at this point, as "data" is json.RawMessage
+		var parsedLine checkpointOrEvent
+		if err := json.Unmarshal(line, &parsedLine); err != nil {
+			return err
+		}
+		if parsedLine.Cursor != "" {
+			// checkpoint
+			if err := r.Checkpoint(parsedLine.Cursor); err != nil {
+				return err
+			}
+
+		} else {
+			// event
+			if err := r.Event(parsedLine.Data); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/go/errors.go
+++ b/go/errors.go
@@ -34,4 +34,5 @@ var (
 	ErrHandshakePartitionCountMismatch = NewAPIError("handshake error: partition count mismatch", http.StatusBadRequest)
 	ErrCursorsMissing                  = NewAPIError("cursors are missing", http.StatusBadRequest)
 	ErrPartitionDoesntExist            = NewAPIError("partition doesn't exist", http.StatusBadRequest)
+	ErrIllegalToken                    = NewAPIError("illegal token, please fetch new from discovery endpoint", http.StatusConflict)
 )

--- a/go/fixture_test.go
+++ b/go/fixture_test.go
@@ -18,12 +18,9 @@ func init() {
 }
 
 func Server(publisher EventPublisher) *httptest.Server {
-	handlers := HTTPHandlers{
-		EventPublisher: publisher,
-		LoggerFromRequest: func(*http.Request) logrus.FieldLogger {
-			return logger
-		},
-	}
+	handlers := NewHTTPHandlers(publisher, func(*http.Request) logrus.FieldLogger {
+		return logger
+	})
 
 	routingHandler := func(w http.ResponseWriter, r *http.Request) {
 		// expose the feed on "testfeed"
@@ -66,8 +63,18 @@ func (t TestZeroEventHubAPI) GetName() string {
 	return "TestZeroEventHubAPI"
 }
 
-func (t TestZeroEventHubAPI) GetPartitionCount() int {
-	return 2
+func (t TestZeroEventHubAPI) GetFeedInfo() FeedInfo {
+	return FeedInfo{
+		Token: "the-token",
+		Partitions: []Partition{
+			{
+				Id: 0,
+			},
+			{
+				Id: 1,
+			},
+		},
+	}
 }
 
 func (t TestZeroEventHubAPI) FetchEvents(ctx context.Context, token string, partitionID int, cursor string, receiver EventReceiver, options Options) error {

--- a/go/fixture_test.go
+++ b/go/fixture_test.go
@@ -1,0 +1,138 @@
+package zeroeventhub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+)
+
+var logger *logrus.Logger
+
+func init() {
+	logger = logrus.StandardLogger()
+	logger.SetLevel(logrus.DebugLevel)
+}
+
+func Server(publisher EventPublisher) *httptest.Server {
+	handlers := HTTPHandlers{
+		EventPublisher: publisher,
+		LoggerFromRequest: func(*http.Request) logrus.FieldLogger {
+			return logger
+		},
+	}
+
+	routingHandler := func(w http.ResponseWriter, r *http.Request) {
+		// expose the feed on "testfeed"
+		if r.URL.Path == "/testfeed" {
+			handlers.DiscoveryHandler(w, r)
+			return
+		} else if r.URL.Path == "/testfeed/events" {
+			handlers.EventsHandler(w, r)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(routingHandler))
+}
+
+func NewTestZeroEventHubAPI() *TestZeroEventHubAPI {
+	api := TestZeroEventHubAPI{partitions: map[int][]TestEvent{}}
+	partition0 := make([]TestEvent, 10000)
+	partition1 := make([]TestEvent, 10000)
+	for i := 0; i < 10000; i++ {
+		partition0[i] = TestEvent{
+			ID:      fmt.Sprintf("00000000-0000-0000-0000-%012x", i),
+			Version: 0,
+			Cursor:  i,
+		}
+		partition1[i] = TestEvent{
+			ID:      fmt.Sprintf("11111111-0000-0000-0000-%012x", i),
+			Version: 0,
+			Cursor:  i,
+		}
+	}
+	api.partitions[0] = partition0
+	api.partitions[1] = partition1
+	return &api
+}
+
+func (t TestZeroEventHubAPI) GetName() string {
+	return "TestZeroEventHubAPI"
+}
+
+func (t TestZeroEventHubAPI) GetPartitionCount() int {
+	return 2
+}
+
+func (t TestZeroEventHubAPI) FetchEvents(ctx context.Context, cursors []Cursor, pageSizeHint int, r EventReceiver, headers ...string) error {
+	if pageSizeHint == DefaultPageSize {
+		pageSizeHint = 100
+	}
+	for _, cursor := range cursors {
+		partition, ok := t.partitions[cursor.PartitionID]
+		if !ok {
+			return ErrPartitionDoesntExist
+		}
+		var err error
+		var lastProcessedCursor int
+		switch cursor.Cursor {
+		case FirstCursor:
+			lastProcessedCursor = -100
+		case LastCursor:
+			lastProcessedCursor = len(partition) - 2
+		// Mock responses: set the cursor to one of the following values to get a mocked response.
+		case cursorReturn500:
+			return err500
+		case cursorReturn504:
+			return err504
+		default:
+			lastProcessedCursor, err = strconv.Atoi(cursor.Cursor)
+			if err != nil {
+				return err
+			}
+		}
+		eventsProcessed := 0
+		h := make(map[string]string, 1)
+		for _, header := range headers {
+			if header == "content-type" {
+				h["content-type"] = "application/json"
+				break
+			}
+			if header == All {
+				h["content-type"] = "application/json"
+				h["foo"] = "bar"
+				break
+			}
+		}
+		for _, event := range partition {
+			if event.Cursor > lastProcessedCursor {
+				if err := r.Event(cursor.PartitionID, h, mustMarshalJson(partition[event.Cursor])); err != nil {
+					return err
+				}
+				if err := r.Checkpoint(cursor.PartitionID, fmt.Sprintf("%d", event.Cursor)); err != nil {
+					return err
+				}
+				lastProcessedCursor = event.Cursor
+				eventsProcessed++
+			}
+			if eventsProcessed == pageSizeHint {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func mustMarshalJson(e any) json.RawMessage {
+	result, err := json.Marshal(e)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}

--- a/go/interfaces.go
+++ b/go/interfaces.go
@@ -26,9 +26,13 @@ type Cursor struct {
 // Checkpoint in this context is basically a cursor.
 type EventReceiver interface {
 	// Event method processes actual events.
-	Event(partitionID int, headers map[string]string, Data json.RawMessage) error
+	Event(Data json.RawMessage) error
 	// Checkpoint method processes cursors.
-	Checkpoint(partitionID int, cursor string) error
+	Checkpoint(cursor string) error
+}
+
+type Options struct {
+	PageSizeHint int
 }
 
 // EventFetcher is a generic-based interface providing a contract for fetching events: both for the server side and
@@ -37,5 +41,5 @@ type EventFetcher interface {
 	// FetchEvents method accepts array of Cursor's along with an optional page size hint and an EventReceiver.
 	// Pass pageSizeHint = 0 for having the server choose a default / no hint.
 	// Optional `headers` argument specifies headers to be returned, or none, if it's absent.
-	FetchEvents(ctx context.Context, cursors []Cursor, pageSizeHint int, receiver EventReceiver, headers ...string) error
+	FetchEvents(ctx context.Context, token string, partitionID int, cursor string, receiver EventReceiver, options Options) error
 }

--- a/go/server_v1.go
+++ b/go/server_v1.go
@@ -1,0 +1,69 @@
+package zeroeventhub
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func (h HTTPHandlers) ZeroEventHubV1Handler(writer http.ResponseWriter, request *http.Request) {
+	partitionCount := len(h.eventPublisher.GetFeedInfo().Partitions)
+	logger := h.loggerFromRequest(request)
+	query := request.URL.Query()
+	if !query.Has("n") {
+		http.Error(writer, ErrHandshakePartitionCountMissing.Error(), ErrHandshakePartitionCountMissing.Status())
+		return
+	}
+	if n, err := strconv.Atoi(query.Get("n")); err != nil {
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	} else {
+		if n != partitionCount {
+			http.Error(writer, ErrHandshakePartitionCountMismatch.Error(), ErrHandshakePartitionCountMismatch.Status())
+			return
+		}
+	}
+	pageSizeHint := DefaultPageSize
+	if query.Has("pagesizehint") {
+		if x, err := strconv.Atoi(query.Get("pagesizehint")); err != nil {
+			http.Error(writer, err.Error(), http.StatusBadRequest)
+			return
+		} else {
+			pageSizeHint = x
+		}
+	}
+	var headers []string
+	if query.Has("headers") {
+		headers = strings.Split(strings.TrimSuffix(query.Get("headers"), ","), ",")
+	}
+	cursors := parseCursors(partitionCount, query)
+	if len(cursors) == 0 {
+		http.Error(writer, ErrCursorsMissing.message, http.StatusBadRequest)
+		return
+	} else if len(cursors) > 1 {
+		// we used to support multiple cursors in the v1 protocol. This feature went unused
+		// and was then deprecated; but that is the reason for the strange signature.
+		http.Error(writer, "support for multiple cursors in the same request has been removed", http.StatusBadRequest)
+		return
+	}
+	partitionID := cursors[0].PartitionID
+	cursor := cursors[0].Cursor
+
+	fields := logger.
+		WithField("event", h.eventPublisher.GetName()).
+		WithField("PartitionCount", partitionCount).
+		WithField("partitionID", partitionID).
+		WithField("cursors", cursor).
+		WithField("PageSizeHint", pageSizeHint).
+		WithField("Headers", headers)
+	fields.Info()
+	serializer := NewNDJSONEventSerializer(writer)
+	err := h.eventPublisher.FetchEvents(request.Context(), "", partitionID, cursor, serializer, Options{
+		PageSizeHint: pageSizeHint,
+	})
+	if err != nil {
+		logger.WithField("event", h.eventPublisher.GetName()+".fetch_events_error").WithError(err).Info()
+		http.Error(writer, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/go/v2_test.go
+++ b/go/v2_test.go
@@ -1,0 +1,1 @@
+package zeroeventhub

--- a/go/v2_test.go
+++ b/go/v2_test.go
@@ -1,1 +1,156 @@
 package zeroeventhub
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestAPI_V2_HappyDay_Smoketest(t *testing.T) {
+	server := Server(NewTestZeroEventHubAPI())
+
+	client := createZehClientWithPartitionCount(server, NoV1Support)
+
+	info, err := client.Discover(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "the-token", info.Token)
+	assert.Equal(t, 2, len(info.Partitions))
+
+	var page EventPageSingleType[TestEvent]
+	err = client.FetchEvents(context.Background(), info.Token, info.Partitions[0].Id, "9998", &page, Options{})
+	require.NoError(t, err)
+
+	assert.Equal(t, TestEvent{
+		ID:      "00000000-0000-0000-0000-00000000270f",
+		Version: 0,
+		Cursor:  9999,
+	}, page.Events[0])
+}
+
+type mockFeedInfo struct {
+	info FeedInfo
+}
+
+func (m mockFeedInfo) GetName() string {
+	return "mockFeedInfo"
+}
+
+func (m mockFeedInfo) GetFeedInfo() FeedInfo {
+	return m.info
+}
+
+func (m mockFeedInfo) FetchEvents(ctx context.Context, token string, partitionID int, cursor string, receiver EventReceiver, options Options) error {
+	panic("unexpected")
+}
+
+func TestDiscoverEndpoint(t *testing.T) {
+	// No parameters, so rather simple test, just check the struct is marshalled through
+	info := FeedInfo{
+		Token: "some-token",
+		Partitions: []Partition{
+			{
+				Id:     23423,
+				Closed: true,
+			},
+			{
+				Id:                   4543252,
+				StartsAfterPartition: 23423,
+			},
+			{
+				Id:                   83223,
+				CursorFromPartitions: []int{23423, 4543252},
+			},
+		},
+		ExactlyOnce: true,
+	}
+
+	server := Server(mockFeedInfo{info})
+	client := createZehClientWithPartitionCount(server, NoV1Support)
+	gotInfo, err := client.Discover(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, info, gotInfo)
+}
+
+func TestEventsEndpoint(t *testing.T) {
+	server := Server(NewTestZeroEventHubAPI())
+	tests := []struct {
+		name string
+
+		token        string
+		pageSizeHint int
+		partitionID  int
+		cursor       string
+
+		expectedEvents      int
+		expectedErrorString string
+	}{
+		{
+			name:                "token mismatch",
+			token:               "wrong-token",
+			partitionID:         0,
+			cursor:              "qwerty",
+			expectedErrorString: "response code 409, response body: illegal token, please fetch new from discovery endpoint\n",
+		},
+		{
+			name:                "wrong cursor",
+			token:               "the-token",
+			partitionID:         0,
+			cursor:              "qwerty",
+			expectedErrorString: "response code 500, response body: Internal server error\n",
+		},
+		{
+			name:           "out of range cursor",
+			token:          "the-token",
+			partitionID:    0,
+			cursor:         "20000",
+			expectedEvents: 0,
+		},
+		{
+			name:           "_first special cursor",
+			token:          "the-token",
+			partitionID:    0,
+			cursor:         FirstCursor,
+			expectedEvents: 100,
+		},
+		{
+			name:           "_last special cursor",
+			token:          "the-token",
+			partitionID:    0,
+			cursor:         LastCursor,
+			expectedEvents: 1,
+		},
+		{
+			name:           "pagesizehint 10000, full page",
+			token:          "the-token",
+			pageSizeHint:   10000,
+			partitionID:    0,
+			cursor:         FirstCursor,
+			expectedEvents: 10000,
+		},
+		{
+			name:           "pagesizehint 10000, half page",
+			token:          "the-token",
+			pageSizeHint:   10000,
+			partitionID:    0,
+			cursor:         "4999",
+			expectedEvents: 5000,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var page EventPageSingleType[TestEvent]
+
+			client := createZehClientWithPartitionCount(server, NoV1Support)
+			err := client.FetchEvents(context.Background(), test.token, test.partitionID, test.cursor, &page, Options{
+				PageSizeHint: test.pageSizeHint,
+			})
+			if err == nil {
+				require.Equal(t, test.expectedEvents, len(page.Events))
+			} else {
+				require.Equal(t, test.expectedErrorString, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds FeedAPI support to ZeroEventHub.

Once this is approved, I plan to copy the code over to https://github.com/vippsas/feedapi-go instead, so that this internal API change will hit when clients do a rename to FeedAPI...